### PR TITLE
Fix DocumentationFile Directory Incorrect Path

### DIFF
--- a/OWSInstanceManagement/OWSInstanceManagement.csproj
+++ b/OWSInstanceManagement/OWSInstanceManagement.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <DocumentationFile>C:\Users\eric\source\repos\OWS\OWSInstanceManagement\OWSInstanceManagement.xml</DocumentationFile>
+    <DocumentationFile>OWSInstanceManagement.xml</DocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fixed DocumentationFile incorrect directory path failing on build.