### PR TITLE
Added max char length limit for ValidateCharacterName in order to match current database column config

### DIFF
--- a/src/OWSShared/Implementations/DefaultPublicAPIInputValidation.cs
+++ b/src/OWSShared/Implementations/DefaultPublicAPIInputValidation.cs
@@ -10,17 +10,17 @@ namespace OWSShared.Implementations
     {
         public string ValidateCharacterName(string charName)
         {
-            //Test for empty Character Names or Character Names that are shorter than the minimum Character name Length
-            if (String.IsNullOrEmpty(charName) || charName.Length < 4)
+            // Test for empty Character Names or Character Names that are shorter or higher than the allowed range for Character name
+            if (String.IsNullOrEmpty(charName) || charName.Length < 4 || charName.Length > 50)
             {
-                return "Please enter a valid Character Name that is at least 4 characters in length.";
+                return "Please enter a valid Character Name that is in range between 4 and 50 characters.";
             }
 
-            //Test for Character Names that use characters other than Letters (uppercase and lowercase) and Numbers.
+            // Test for Character Names that use characters other than Letters (uppercase and lowercase) and Numbers (A-Z & 0-9)
             Regex regex = new Regex(@"^\w+$");
             if (!regex.IsMatch(charName))
             {
-                return "Please enter a Character Name that only contains letters and numbers.";
+                return "Please enter a Character Name that only contains letters and numbers (A-Z & 0-9).";
             }
 
             return "";


### PR DESCRIPTION
What's up with it? Well, basically there should be a max length limit that prevents someone from sending a request to the database with a bigger name ... in other words, even if DB would successfully prevent it by returning error (or most likely trimming it) ... it is still wrong and no db hit should be done in the first place.

- Tested and working as intended.
- Edits allowed by maintainers.