### PR TITLE
fix: Variable UserSessionGUID is being generated but not being stored.

### DIFF
--- a/plugins/OWSPlugin/Source/OWSPlugin/Private/OWSGameMode.cpp
+++ b/plugins/OWSPlugin/Source/OWSPlugin/Private/OWSGameMode.cpp
@@ -202,6 +202,7 @@ FString AOWSGameMode::InitNewPlayer(APlayerController* NewPlayerController, cons
 		PRZ = SplitArray[5];
 		PlayerName1 = SplitArray[6];
 		UserSessionGUID = SplitArray[7];
+		this->UserSessionGUID = UserSessionGUID;
 
 		UE_LOG(OWS, Warning, TEXT("PlayerName: %s"), *PlayerName1);
 		UE_LOG(OWS, Warning, TEXT("UserSessionGUID: %s"), *UserSessionGUID);


### PR DESCRIPTION
The session Id should be kept only on single variable , and when generated , be stored at that address until logout.