### PR TITLE
feat(status): add system status api to globaldata

### DIFF
--- a/src/.docker/extensions/heartbeat/config/heartbeat.yml
+++ b/src/.docker/extensions/heartbeat/config/heartbeat.yml
@@ -21,7 +21,13 @@ heartbeat.monitors:
   name: OWSCharacterPersistence
   hosts: ["http://host.docker.internal:44323/api/system/status"]
   timeout: 60s
-    
+
+- type: http
+  schedule: '@every 30s'
+  name: OWSGlobalData
+  hosts: ["http://host.docker.internal:44326/api/system/status"]
+  timeout: 60s
+
 - type: tcp
   schedule: '@every 30s'
   name: MSSQL

--- a/src/OWSGlobalData/Controllers/SystemController.cs
+++ b/src/OWSGlobalData/Controllers/SystemController.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using System.Threading.Tasks;
+
+namespace OWSGlobalData.Controllers
+{
+    /// <summary>
+    /// Public System API calls.
+    /// </summary>
+    /// <remarks>
+    /// Contains system related API calls that are all publicly accessible.
+    /// </remarks>
+    [Route("api/[controller]")]
+    [ApiController]
+    public class SystemController : Controller
+    {
+        /// <summary>
+        /// Gets the Api Status.
+        /// </summary>
+        /// <remarks>
+        /// Get the Api Status and return true
+        /// </remarks>
+        [HttpGet]
+        [Route("Status")]
+        public IActionResult Status()
+        {
+            return Ok(true);
+        }
+    }
+}

--- a/src/OWSGlobalData/OWSGlobalData.xml
+++ b/src/OWSGlobalData/OWSGlobalData.xml
@@ -4,6 +4,22 @@
         <name>OWSGlobalData</name>
     </assembly>
     <members>
+        <member name="T:OWSGlobalData.Controllers.SystemController">
+            <summary>
+                Public System API calls.
+            </summary>
+            <remarks>
+                Contains system related API calls that are all publicly accessible.
+            </remarks>
+        </member>
+        <member name="M:OWSGlobalData.Controllers.SystemController.Status">
+            <summary>
+                Gets the Api Status.
+            </summary>
+            <remarks>
+                Get the Api Status and return true
+            </remarks>
+        </member>
         <member name="M:OWSGlobalData.Controllers.GlobalDataController.AddOrUpdateGlobalDataItem(OWSGlobalData.DTOs.AddOrUpdateGlobalDataItemDTO)">
             <summary>
             Add an item to Global Data


### PR DESCRIPTION
Add `/api/system/status` endpoint to OWS Global Data and also to heartbeat