### PR TITLE
.Net 8 testing - OWS seens to be running fine

### DIFF
--- a/src/.docker/logging.yml
+++ b/src/.docker/logging.yml
@@ -37,7 +37,7 @@ services:
       - "9200:9200"
       - "9300:9300"
     environment:
-      ES_JAVA_OPTS: -Xmx256m -Xms256m
+      ES_JAVA_OPTS: -Xmx512m -Xms512m
       # Bootstrap password.
       # Used to initialize the keystore during the initial startup of
       # Elasticsearch. Ignored on subsequent runs.
@@ -62,7 +62,7 @@ services:
       - "50000:50000"
       - "9600:9600"
     environment:
-      LS_JAVA_OPTS: -Xmx256m -Xms256m
+      LS_JAVA_OPTS: -Xmx512m -Xms512m
       LOGSTASH_INTERNAL_PASSWORD: ${LOGSTASH_INTERNAL_PASSWORD:-}
     networks:
       - elk

--- a/src/.docker/mssql/Dockerfile
+++ b/src/.docker/mssql/Dockerfile
@@ -1,6 +1,9 @@
-FROM mcr.microsoft.com/mssql/server:2017-CU24-ubuntu-16.04
+FROM mcr.microsoft.com/mssql/server:2022-preview-ubuntu-22.04
+
+USER root
 
 RUN mkdir -p /user/config
+RUN mkdir -p /var/opt/mssql/data
 WORKDIR /user/config
 
 COPY . /user/config
@@ -8,6 +11,13 @@ COPY . /user/config
 RUN chmod +x /user/config/entrypoint.sh
 RUN chmod +x /user/config/initialization.sh
 
-EXPOSE 1433
+RUN groupadd --gid 1001 mssql \
+    && useradd --uid 1001 --gid 1001 -m mssqlapp
 
+RUN chown -R mssqlapp:mssql /user/config
+RUN chown -R mssqlapp:mssql /var/opt/mssql
+RUN chown -R mssqlapp:mssql /var/opt/mssql/data
+
+USER mssqlapp
+EXPOSE 1433
 ENTRYPOINT ["./entrypoint.sh"]

--- a/src/.docker/mssql/Dockerfile
+++ b/src/.docker/mssql/Dockerfile
@@ -12,12 +12,12 @@ RUN chmod +x /user/config/entrypoint.sh
 RUN chmod +x /user/config/initialization.sh
 
 RUN groupadd --gid 1001 mssql \
-    && useradd --uid 1001 --gid 1001 -m mssqlapp
+    && useradd --uid 1001 --gid 1001 -m mssqluser
 
-RUN chown -R mssqlapp:mssql /user/config
-RUN chown -R mssqlapp:mssql /var/opt/mssql
-RUN chown -R mssqlapp:mssql /var/opt/mssql/data
+RUN chown -R mssqluser:mssql /user/config
+RUN chown -R mssqluser:mssql /var/opt/mssql
+RUN chown -R mssqluser:mssql /var/opt/mssql/data
 
-USER mssqlapp
+USER mssqluser
 EXPOSE 1433
 ENTRYPOINT ["./entrypoint.sh"]

--- a/src/.env
+++ b/src/.env
@@ -1,8 +1,8 @@
 COMPOSE_PROJECT_NAME=ows2
 
 
-ELASTIC_VERSION=8.1.3
-
+ELASTIC_VERSION=8.10.1
+ES_PORT=127.0.0.1:9200
 # User 'elastic' (built-in)
 #
 # Superuser role, full access to cluster management and data indices.

--- a/src/.env
+++ b/src/.env
@@ -2,7 +2,6 @@ COMPOSE_PROJECT_NAME=ows2
 
 
 ELASTIC_VERSION=8.10.1
-ES_PORT=127.0.0.1:9200
 # User 'elastic' (built-in)
 #
 # Superuser role, full access to cluster management and data indices.

--- a/src/OWSBenchmarks/OWSBenchmarks.csproj
+++ b/src/OWSBenchmarks/OWSBenchmarks.csproj
@@ -1,18 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="0.13.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.0-rc.1.23421.29" />
   </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\OWSData\OWSData.csproj" />
     <ProjectReference Include="..\OWSPublicAPI\OWSPublicAPI.csproj" />
   </ItemGroup>
-
 </Project>

--- a/src/OWSCharacterPersistence/Dockerfile
+++ b/src/OWSCharacterPersistence/Dockerfile
@@ -1,15 +1,11 @@
 #See https://aka.ms/containerfastmode to understand how Visual Studio uses this Dockerfile to build your images for faster debugging.
 
-# FROM mcr.microsoft.com/dotnet/aspnet:6.0 AS base
-FROM mcr.microsoft.com/dotnet/aspnet:6.0-alpine AS base
-RUN addgroup -S dotnet && adduser -S dotnet -G dotnet \
-    && apk add --no-cache dumb-init
+FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base
 WORKDIR /app
 EXPOSE 80
 EXPOSE 443
 
-# FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
-FROM mcr.microsoft.com/dotnet/sdk:6.0-alpine AS build
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 WORKDIR /src
 COPY ["OWSCharacterPersistence/OWSCharacterPersistence.csproj", "OWSCharacterPersistence/"]
 COPY ["OWSShared/OWSShared.csproj", "OWSShared/"]
@@ -25,6 +21,4 @@ RUN dotnet publish "OWSCharacterPersistence.csproj" -c Release -o /app/publish
 FROM base AS final
 WORKDIR /app
 COPY --from=publish /app/publish .
-USER dotnet
-# ENTRYPOINT ["dotnet", "OWSCharacterPersistence.dll"]
-CMD ["dumb-init", "dotnet", "OWSCharacterPersistence.dll"]
+ENTRYPOINT ["dotnet", "OWSCharacterPersistence.dll"]

--- a/src/OWSCharacterPersistence/Dockerfile
+++ b/src/OWSCharacterPersistence/Dockerfile
@@ -1,11 +1,15 @@
 #See https://aka.ms/containerfastmode to understand how Visual Studio uses this Dockerfile to build your images for faster debugging.
 
-FROM mcr.microsoft.com/dotnet/aspnet:6.0 AS base
+# FROM mcr.microsoft.com/dotnet/aspnet:6.0 AS base
+FROM mcr.microsoft.com/dotnet/aspnet:6.0-alpine AS base
+RUN addgroup -S dotnet && adduser -S dotnet -G dotnet \
+    && apk add --no-cache dumb-init
 WORKDIR /app
 EXPOSE 80
 EXPOSE 443
 
-FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
+# FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:6.0-alpine AS build
 WORKDIR /src
 COPY ["OWSCharacterPersistence/OWSCharacterPersistence.csproj", "OWSCharacterPersistence/"]
 COPY ["OWSShared/OWSShared.csproj", "OWSShared/"]
@@ -21,4 +25,6 @@ RUN dotnet publish "OWSCharacterPersistence.csproj" -c Release -o /app/publish
 FROM base AS final
 WORKDIR /app
 COPY --from=publish /app/publish .
-ENTRYPOINT ["dotnet", "OWSCharacterPersistence.dll"]
+USER dotnet
+# ENTRYPOINT ["dotnet", "OWSCharacterPersistence.dll"]
+CMD ["dumb-init", "dotnet", "OWSCharacterPersistence.dll"]

--- a/src/OWSCharacterPersistence/OWSCharacterPersistence.csproj
+++ b/src/OWSCharacterPersistence/OWSCharacterPersistence.csproj
@@ -1,24 +1,19 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
-
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <UserSecretsId>f3bb93df-33d8-4372-b1d5-43a2c186459a</UserSecretsId>
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
     <DockerComposeProjectPath>..\docker-compose.dcproj</DockerComposeProjectPath>
   </PropertyGroup>
-
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <DocumentationFile>OWSCharacterPersistence.xml</DocumentationFile>
   </PropertyGroup>
-
   <ItemGroup>
     <None Include="..\.dockerignore" Link=".dockerignore">
       <DependentUpon>$(DockerDefaultDockerfile)</DependentUpon>
     </None>
   </ItemGroup>
-
   <ItemGroup>
-    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="5.0.2" />
     <PackageReference Include="SimpleInjector" Version="5.4.1" />
     <PackageReference Include="SimpleInjector.Integration.AspNetCore.Mvc" Version="5.4.0" />
     <PackageReference Include="Serilog.AspNetCore" Version="7.0.0" />
@@ -36,16 +31,14 @@
     <PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="6.5.0" />
     <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="6.5.0" />
     <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="6.5.0" />
+    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="8.0.0-rc.1.23461.3" />
   </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\OWSShared\OWSShared.csproj" />
   </ItemGroup>
-
   <ItemGroup>
     <None Update="OWSCharacterPersistence.xml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
-
 </Project>

--- a/src/OWSData/OWSData.csproj
+++ b/src/OWSData/OWSData.csproj
@@ -1,20 +1,17 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
-	  <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="Dapper" Version="2.0.138" />
     <PackageReference Include="Dapper.Transaction" Version="2.0.123" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.7" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Abstractions" Version="7.0.7" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="7.0.7" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.7" />
     <PackageReference Include="MongoDB.Driver" Version="2.19.2" />
     <PackageReference Include="MySql.Data" Version="8.0.33" />
     <PackageReference Include="Npgsql" Version="7.0.4" />
     <PackageReference Include="System.Data.SqlClient" Version="4.8.5" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0-rc.1.23419.6" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Abstractions" Version="8.0.0-rc.1.23419.6" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.0-rc.1.23419.6" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0-rc.1.23419.6" />
   </ItemGroup>
-
 </Project>

--- a/src/OWSExternalLoginProviders/OWSExternalLoginProviders.csproj
+++ b/src/OWSExternalLoginProviders/OWSExternalLoginProviders.csproj
@@ -1,14 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="IdentityModel" Version="6.1.0" />
     <PackageReference Include="IdentityModel.AspNetCore" Version="4.3.0" />
     <PackageReference Include="Serilog" Version="2.12.0" />
     <PackageReference Include="SimpleInjector" Version="5.4.1" />
   </ItemGroup>
-
 </Project>

--- a/src/OWSGlobalData/Dockerfile
+++ b/src/OWSGlobalData/Dockerfile
@@ -1,15 +1,11 @@
 #See https://aka.ms/containerfastmode to understand how Visual Studio uses this Dockerfile to build your images for faster debugging.
 
-# FROM mcr.microsoft.com/dotnet/aspnet:6.0 AS base
-FROM mcr.microsoft.com/dotnet/aspnet:6.0-alpine AS base
-RUN addgroup -S dotnet && adduser -S dotnet -G dotnet \
-    && apk add --no-cache dumb-init
+FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base
 WORKDIR /app
 EXPOSE 80
 EXPOSE 443
 
-# FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
-FROM mcr.microsoft.com/dotnet/sdk:6.0-alpine AS build
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 WORKDIR /src
 COPY ["OWSGlobalData/OWSGlobalData.csproj", "OWSGlobalData/"]
 COPY ["OWSShared/OWSShared.csproj", "OWSShared/"]
@@ -25,6 +21,4 @@ RUN dotnet publish "OWSGlobalData.csproj" -c Release -o /app/publish
 FROM base AS final
 WORKDIR /app
 COPY --from=publish /app/publish .
-USER dotnet
-# ENTRYPOINT ["dotnet", "OWSGlobalData.dll"]
-CMD ["dumb-init", "dotnet", "OWSGlobalData.dll"]
+ENTRYPOINT ["dotnet", "OWSGlobalData.dll"]

--- a/src/OWSGlobalData/Dockerfile
+++ b/src/OWSGlobalData/Dockerfile
@@ -1,11 +1,15 @@
 #See https://aka.ms/containerfastmode to understand how Visual Studio uses this Dockerfile to build your images for faster debugging.
 
-FROM mcr.microsoft.com/dotnet/aspnet:6.0 AS base
+# FROM mcr.microsoft.com/dotnet/aspnet:6.0 AS base
+FROM mcr.microsoft.com/dotnet/aspnet:6.0-alpine AS base
+RUN addgroup -S dotnet && adduser -S dotnet -G dotnet \
+    && apk add --no-cache dumb-init
 WORKDIR /app
 EXPOSE 80
 EXPOSE 443
 
-FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
+# FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:6.0-alpine AS build
 WORKDIR /src
 COPY ["OWSGlobalData/OWSGlobalData.csproj", "OWSGlobalData/"]
 COPY ["OWSShared/OWSShared.csproj", "OWSShared/"]
@@ -21,4 +25,6 @@ RUN dotnet publish "OWSGlobalData.csproj" -c Release -o /app/publish
 FROM base AS final
 WORKDIR /app
 COPY --from=publish /app/publish .
-ENTRYPOINT ["dotnet", "OWSGlobalData.dll"]
+USER dotnet
+# ENTRYPOINT ["dotnet", "OWSGlobalData.dll"]
+CMD ["dumb-init", "dotnet", "OWSGlobalData.dll"]

--- a/src/OWSGlobalData/OWSGlobalData.csproj
+++ b/src/OWSGlobalData/OWSGlobalData.csproj
@@ -1,22 +1,18 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
-
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <UserSecretsId>f2bb93df-33d8-4372-b1d5-43a2c186459a</UserSecretsId>
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
     <DockerComposeProjectPath>..\docker-compose.dcproj</DockerComposeProjectPath>
   </PropertyGroup>
-
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <DocumentationFile>OWSGlobalData.xml</DocumentationFile>
   </PropertyGroup>
-
   <ItemGroup>
     <None Include="..\.dockerignore" Link=".dockerignore">
       <DependentUpon>$(DockerDefaultDockerfile)</DependentUpon>
     </None>
   </ItemGroup>
-
   <ItemGroup>
     <PackageReference Include="Serilog.AspNetCore" Version="7.0.0" />
     <PackageReference Include="Serilog.Enrichers.ClientInfo" Version="1.3.0" />
@@ -37,15 +33,12 @@
     <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="6.5.0" />
     <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="6.5.0" />
   </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\OWSShared\OWSShared.csproj" />
   </ItemGroup>
-
   <ItemGroup>
     <None Update="OWSGlobaldata.xml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
-
 </Project>

--- a/src/OWSInstanceLauncher/OWSInstanceLauncher.csproj
+++ b/src/OWSInstanceLauncher/OWSInstanceLauncher.csproj
@@ -1,14 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
-
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <StartupObject>OWSInstanceLauncher.Program</StartupObject>
   </PropertyGroup>
-
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.2.5" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="7.0.0" />
-    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="6.0.7" />
     <PackageReference Include="RabbitMQ.Client" Version="6.5.0" />
     <PackageReference Include="Serilog.AspNetCore" Version="7.0.0" />
     <PackageReference Include="Serilog.Enrichers.ClientInfo" Version="1.3.0" />
@@ -22,11 +17,11 @@
     <PackageReference Include="SimpleInjector" Version="5.4.1" />
     <PackageReference Include="SimpleInjector.Integration.AspNetCore.Mvc" Version="5.4.0" />
     <PackageReference Include="SimpleInjector.Integration.GenericHost" Version="5.4.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0-rc.1.23419.4" />
+    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="8.0.0-rc.1.23461.3" />
   </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\OWSData\OWSData.csproj" />
     <ProjectReference Include="..\OWSShared\OWSShared.csproj" />
   </ItemGroup>
-
 </Project>

--- a/src/OWSInstanceManagement/Dockerfile
+++ b/src/OWSInstanceManagement/Dockerfile
@@ -1,11 +1,15 @@
 #See https://aka.ms/containerfastmode to understand how Visual Studio uses this Dockerfile to build your images for faster debugging.
 
-FROM mcr.microsoft.com/dotnet/aspnet:6.0 AS base
+# FROM mcr.microsoft.com/dotnet/aspnet:6.0 AS base
+FROM mcr.microsoft.com/dotnet/aspnet:6.0-alpine AS base
+RUN addgroup -S dotnet && adduser -S dotnet -G dotnet \
+    && apk add --no-cache dumb-init
 WORKDIR /app
 EXPOSE 80
 EXPOSE 443
 
-FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
+# FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:6.0-alpine AS build
 WORKDIR /src
 COPY ["OWSInstanceManagement/OWSInstanceManagement.csproj", "OWSInstanceManagement/"]
 COPY ["OWSShared/OWSShared.csproj", "OWSShared/"]
@@ -21,4 +25,6 @@ RUN dotnet publish "OWSInstanceManagement.csproj" -c Release -o /app/publish
 FROM base AS final
 WORKDIR /app
 COPY --from=publish /app/publish .
-ENTRYPOINT ["dotnet", "OWSInstanceManagement.dll"]
+USER dotnet
+# ENTRYPOINT ["dotnet", "OWSInstanceManagement.dll"]
+CMD ["dumb-init", "dotnet", "OWSInstanceManagement.dll"]

--- a/src/OWSInstanceManagement/Dockerfile
+++ b/src/OWSInstanceManagement/Dockerfile
@@ -1,15 +1,11 @@
 #See https://aka.ms/containerfastmode to understand how Visual Studio uses this Dockerfile to build your images for faster debugging.
 
-# FROM mcr.microsoft.com/dotnet/aspnet:6.0 AS base
-FROM mcr.microsoft.com/dotnet/aspnet:6.0-alpine AS base
-RUN addgroup -S dotnet && adduser -S dotnet -G dotnet \
-    && apk add --no-cache dumb-init
+FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base
 WORKDIR /app
 EXPOSE 80
 EXPOSE 443
 
-# FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
-FROM mcr.microsoft.com/dotnet/sdk:6.0-alpine AS build
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 WORKDIR /src
 COPY ["OWSInstanceManagement/OWSInstanceManagement.csproj", "OWSInstanceManagement/"]
 COPY ["OWSShared/OWSShared.csproj", "OWSShared/"]
@@ -25,6 +21,4 @@ RUN dotnet publish "OWSInstanceManagement.csproj" -c Release -o /app/publish
 FROM base AS final
 WORKDIR /app
 COPY --from=publish /app/publish .
-USER dotnet
-# ENTRYPOINT ["dotnet", "OWSInstanceManagement.dll"]
-CMD ["dumb-init", "dotnet", "OWSInstanceManagement.dll"]
+ENTRYPOINT ["dotnet", "OWSInstanceManagement.dll"]

--- a/src/OWSInstanceManagement/OWSInstanceManagement.csproj
+++ b/src/OWSInstanceManagement/OWSInstanceManagement.csproj
@@ -1,26 +1,19 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
-
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <UserSecretsId>e3bb93df-33d8-4372-b1d5-43a2c1864599</UserSecretsId>
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
     <DockerComposeProjectPath>..\docker-compose.dcproj</DockerComposeProjectPath>
   </PropertyGroup>
-
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <DocumentationFile>OWSInstanceManagement.xml</DocumentationFile>
   </PropertyGroup>
-
   <ItemGroup>
     <None Include="..\.dockerignore" Link=".dockerignore">
       <DependentUpon>$(DockerDefaultDockerfile)</DependentUpon>
     </None>
   </ItemGroup>
-
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.2.5" />
-    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.18.1" />
-    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="5.0.2" />
     <PackageReference Include="RabbitMQ.Client" Version="6.5.0" />
     <PackageReference Include="SimpleInjector" Version="5.4.1" />
     <PackageReference Include="SimpleInjector.Integration.AspNetCore.Mvc" Version="5.4.0" />
@@ -39,17 +32,15 @@
     <PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="6.5.0" />
     <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="6.5.0" />
     <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="6.5.0" />
+    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="8.0.0-rc.1.23461.3" />
   </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\OWSData\OWSData.csproj" />
     <ProjectReference Include="..\OWSShared\OWSShared.csproj" />
   </ItemGroup>
-
   <ItemGroup>
     <None Update="OWSInstanceManagement.xml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
-
 </Project>

--- a/src/OWSManagement/Dockerfile
+++ b/src/OWSManagement/Dockerfile
@@ -1,11 +1,15 @@
 #See https://aka.ms/containerfastmode to understand how Visual Studio uses this Dockerfile to build your images for faster debugging.
 
-FROM mcr.microsoft.com/dotnet/aspnet:6.0 AS base
+# FROM mcr.microsoft.com/dotnet/aspnet:6.0 AS base
+FROM mcr.microsoft.com/dotnet/aspnet:6.0-alpine AS base
+RUN addgroup -S dotnet && adduser -S dotnet -G dotnet \
+    && apk add --no-cache dumb-init
 WORKDIR /app
 EXPOSE 80
 EXPOSE 443
 
-FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
+# FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:6.0-alpine AS build
 WORKDIR /src
 COPY ["OWSManagement/OWSManagement.csproj", "OWSManagement/"]
 COPY ["OWSShared/OWSShared.csproj", "OWSShared/"]
@@ -28,4 +32,6 @@ FROM base AS final
 WORKDIR /app
 COPY --from=publish /app/publish .
 COPY --from=build-node /wwwroot/dist ./wwwroot/dist
-ENTRYPOINT ["dotnet", "OWSManagement.dll"]
+USER dotnet
+# ENTRYPOINT ["dotnet", "OWSManagement.dll"]
+CMD ["dumb-init", "dotnet", "OWSManagement.dll"]

--- a/src/OWSManagement/Dockerfile
+++ b/src/OWSManagement/Dockerfile
@@ -1,15 +1,11 @@
 #See https://aka.ms/containerfastmode to understand how Visual Studio uses this Dockerfile to build your images for faster debugging.
 
-# FROM mcr.microsoft.com/dotnet/aspnet:6.0 AS base
-FROM mcr.microsoft.com/dotnet/aspnet:6.0-alpine AS base
-RUN addgroup -S dotnet && adduser -S dotnet -G dotnet \
-    && apk add --no-cache dumb-init
+FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base
 WORKDIR /app
 EXPOSE 80
 EXPOSE 443
 
-# FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
-FROM mcr.microsoft.com/dotnet/sdk:6.0-alpine AS build
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 WORKDIR /src
 COPY ["OWSManagement/OWSManagement.csproj", "OWSManagement/"]
 COPY ["OWSShared/OWSShared.csproj", "OWSShared/"]
@@ -32,6 +28,4 @@ FROM base AS final
 WORKDIR /app
 COPY --from=publish /app/publish .
 COPY --from=build-node /wwwroot/dist ./wwwroot/dist
-USER dotnet
-# ENTRYPOINT ["dotnet", "OWSManagement.dll"]
-CMD ["dumb-init", "dotnet", "OWSManagement.dll"]
+ENTRYPOINT ["dotnet", "OWSManagement.dll"]

--- a/src/OWSManagement/OWSManagement.csproj
+++ b/src/OWSManagement/OWSManagement.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
-
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <UserSecretsId>9805f064-639a-42e6-9e13-a99860a79187</UserSecretsId>
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
     <DockerComposeProjectPath>..\docker-compose.dcproj</DockerComposeProjectPath>
@@ -14,7 +13,6 @@
     <SpaProxyServerUrl>http://localhost:5173</SpaProxyServerUrl>
     <SpaProxyLaunchCommand>npm run dev</SpaProxyLaunchCommand>
   </PropertyGroup>
-
   <ItemGroup>
     <Content Remove="wwwroot\src\components\CharactersGrid.vue" />
     <Content Remove="wwwroot\src\components\WorldServersGrid.vue" />
@@ -22,27 +20,22 @@
     <Content Remove="wwwroot\src\owsApiClient.ts" />
     <Content Remove="wwwroot\src\router\index.ts" />
   </ItemGroup>
-
   <ItemGroup>
     <None Remove="wwwroot\src\plugins\vuetify.ts" />
   </ItemGroup>
-
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.SpaProxy" Version="6.0.13" />
-    <PackageReference Include="Microsoft.AspNetCore.SpaServices.Extensions" Version="6.0.12" />
-    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.15.1" />
     <PackageReference Include="SimpleInjector" Version="5.4.1" />
     <PackageReference Include="SimpleInjector.Integration.AspNetCore.Mvc" Version="5.4.0" />
     <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="6.5.0" />
     <PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="6.5.0" />
     <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="6.5.0" />
     <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="6.5.0" />
+    <PackageReference Include="Microsoft.AspNetCore.SpaProxy" Version="8.0.0-rc.1.23421.29" />
+    <PackageReference Include="Microsoft.AspNetCore.SpaServices.Extensions" Version="8.0.0-rc.1.23421.29" />
   </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\OWSShared\OWSShared.csproj" />
   </ItemGroup>
-
   <ItemGroup>
     <TypeScriptCompile Include="wwwroot\src\components\CharactersGrid.vue" />
     <TypeScriptCompile Include="wwwroot\src\components\WorldServersGrid.vue" />
@@ -51,7 +44,6 @@
     <TypeScriptCompile Include="wwwroot\src\plugins\vuetify.ts" />
     <TypeScriptCompile Include="wwwroot\src\router\index.ts" />
   </ItemGroup>
-
   <ItemGroup>
     <None Update="OWSManagement.xml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/src/OWSPublicAPI/Dockerfile
+++ b/src/OWSPublicAPI/Dockerfile
@@ -1,11 +1,15 @@
 #See https://aka.ms/containerfastmode to understand how Visual Studio uses this Dockerfile to build your images for faster debugging.
 
-FROM mcr.microsoft.com/dotnet/aspnet:6.0 AS base
+# FROM mcr.microsoft.com/dotnet/aspnet:6.0 AS base
+FROM mcr.microsoft.com/dotnet/aspnet:6.0-alpine AS base
+RUN addgroup -S dotnet && adduser -S dotnet -G dotnet \
+    && apk add --no-cache dumb-init
 WORKDIR /app
 EXPOSE 80
 EXPOSE 443
 
-FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
+# FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:6.0-alpine AS build
 WORKDIR /src
 COPY ["OWSPublicAPI/OWSPublicAPI.csproj", "OWSPublicAPI/"]
 COPY ["OWSExternalLoginProviders/OWSExternalLoginProviders.csproj", "OWSExternalLoginProviders/"]
@@ -22,4 +26,6 @@ RUN dotnet publish "OWSPublicAPI.csproj" -c Release -o /app/publish
 FROM base AS final
 WORKDIR /app
 COPY --from=publish /app/publish .
-ENTRYPOINT ["dotnet", "OWSPublicAPI.dll"]
+USER dotnet
+# ENTRYPOINT ["dotnet", "OWSPublicAPI.dll"]
+CMD ["dumb-init", "dotnet", "OWSPublicAPI.dll"]

--- a/src/OWSPublicAPI/Dockerfile
+++ b/src/OWSPublicAPI/Dockerfile
@@ -1,15 +1,11 @@
 #See https://aka.ms/containerfastmode to understand how Visual Studio uses this Dockerfile to build your images for faster debugging.
 
-# FROM mcr.microsoft.com/dotnet/aspnet:6.0 AS base
-FROM mcr.microsoft.com/dotnet/aspnet:6.0-alpine AS base
-RUN addgroup -S dotnet && adduser -S dotnet -G dotnet \
-    && apk add --no-cache dumb-init
+FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base
 WORKDIR /app
 EXPOSE 80
 EXPOSE 443
 
-# FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
-FROM mcr.microsoft.com/dotnet/sdk:6.0-alpine AS build
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 WORKDIR /src
 COPY ["OWSPublicAPI/OWSPublicAPI.csproj", "OWSPublicAPI/"]
 COPY ["OWSExternalLoginProviders/OWSExternalLoginProviders.csproj", "OWSExternalLoginProviders/"]
@@ -26,6 +22,4 @@ RUN dotnet publish "OWSPublicAPI.csproj" -c Release -o /app/publish
 FROM base AS final
 WORKDIR /app
 COPY --from=publish /app/publish .
-USER dotnet
-# ENTRYPOINT ["dotnet", "OWSPublicAPI.dll"]
-CMD ["dumb-init", "dotnet", "OWSPublicAPI.dll"]
+ENTRYPOINT ["dotnet", "OWSPublicAPI.dll"]

--- a/src/OWSPublicAPI/OWSPublicAPI.csproj
+++ b/src/OWSPublicAPI/OWSPublicAPI.csproj
@@ -1,24 +1,19 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
-
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <UserSecretsId>5f287243-b8be-4d52-a0d5-8c329ba8d881</UserSecretsId>
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
     <DockerComposeProjectPath>..\docker-compose.dcproj</DockerComposeProjectPath>
   </PropertyGroup>
-
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <DocumentationFile>OWSPublicAPI.xml</DocumentationFile>
   </PropertyGroup>
-
   <ItemGroup>
     <Folder Include="Views\" />
     <Folder Include="wwwroot\" />
   </ItemGroup>
-
   <ItemGroup>
     <PackageReference Include="Dapper" Version="2.0.138" />
-    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.18.1" />
     <PackageReference Include="Serilog.AspNetCore" Version="7.0.0" />
     <PackageReference Include="Serilog.Enrichers.ClientInfo" Version="1.3.0" />
     <PackageReference Include="Serilog.Enrichers.CorrelationId" Version="3.0.1" />
@@ -37,41 +32,32 @@
     <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="6.5.0" />
     <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="6.5.0" />
   </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\OWSData\OWSData.csproj" />
     <ProjectReference Include="..\OWSExternalLoginProviders\OWSExternalLoginProviders.csproj" />
     <ProjectReference Include="..\OWSShared\OWSShared.csproj" />
   </ItemGroup>
-
   <ItemGroup>
     <None Update="OWSPublicAPI.xml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
-  
   <Target Name="DockerComposeOverrideWindows" BeforeTargets="PreBuildEvent" Condition="$([MSBuild]::IsOSPlatform('Windows'))">
     <ItemGroup>
       <DockerComposeOverrideFile Include="$(SolutionDir)\docker-compose.override.windows.yml" />
     </ItemGroup>
-    
-	<Copy SourceFiles="@(DockerComposeOverrideFile)" DestinationFiles="$(SolutionDir)\docker-compose.override.yml" SkipUnchangedFiles="true" />
+    <Copy SourceFiles="@(DockerComposeOverrideFile)" DestinationFiles="$(SolutionDir)\docker-compose.override.yml" SkipUnchangedFiles="true" />
   </Target>
-  
   <Target Name="DockerComposeOverrideOSX" BeforeTargets="PreBuildEvent" Condition="$([MSBuild]::IsOSPlatform('OSX'))">
     <ItemGroup>
       <DockerComposeOverrideFile Include="$(SolutionDir)\docker-compose.override.osx.yml" />
     </ItemGroup>
-    
-	<Copy SourceFiles="@(DockerComposeOverrideFile)" DestinationFiles="$(SolutionDir)\docker-compose.override.yml" SkipUnchangedFiles="true" />
+    <Copy SourceFiles="@(DockerComposeOverrideFile)" DestinationFiles="$(SolutionDir)\docker-compose.override.yml" SkipUnchangedFiles="true" />
   </Target>
-
   <Target Name="DockerComposeOverrideLinux" BeforeTargets="PreBuildEvent" Condition="$([MSBuild]::IsOSPlatform('Linux'))">
     <ItemGroup>
       <DockerComposeOverrideFile Include="$(SolutionDir)\docker-compose.override.linux.yml" />
     </ItemGroup>
-
     <Copy SourceFiles="@(DockerComposeOverrideFile)" DestinationFiles="$(SolutionDir)\docker-compose.override.yml" SkipUnchangedFiles="true" />
   </Target>
-
 </Project>

--- a/src/OWSShared/OWSShared.csproj
+++ b/src/OWSShared/OWSShared.csproj
@@ -1,22 +1,18 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
-	  <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="7.0.0" />
     <PackageReference Include="RabbitMQ.Client" Version="6.5.0" />
     <PackageReference Include="Serilog" Version="2.12.0" />
     <PackageReference Include="SimpleInjector" Version="5.4.1" />
     <PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="6.5.0" />
     <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="6.5.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.0-rc.1.23419.4" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0-rc.1.23419.4" />
   </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\OWSData\OWSData.csproj" />
   </ItemGroup>
-
 </Project>

--- a/src/OWSTests/OWSTests.csproj
+++ b/src/OWSTests/OWSTests.csproj
@@ -1,30 +1,25 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
-
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="7.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.2" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0-rc.1.23419.4" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0-rc.1.23419.4" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0-rc.1.23419.4" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.0-rc.1.23419.4" />
   </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\OWSShared\OWSShared.csproj" />
   </ItemGroup>
-
   <ItemGroup>
     <None Update="appsettings.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
-
 </Project>


### PR DESCRIPTION
- All 12 projects have been migrated to .Net 8.  In order to test this branch, you are required to install .Net SDK 8 : https://dotnet.microsoft.com/en-us/download/dotnet/8.0

- Then, ensure you are using Visual Studio 2022 (only version supporting .Net 8)
- Under VSStudio 2022, under option, look for Preview features, then check Use Preview of the .Net SDK (requires restart).

- I also updated my Docker Desktop to the latest version to ensure I have the latest runtime with the latest OCI version.

- Part of this branch is MSSQL is now using the latest **MSSQL 2022 image version** and is also secured and using a UID of 1001 (mssqluser).
- logging.yml also been updated to use  LS_JAVA_OPTS from 256m to 512m.

**This branch needs to be tested thoroughly before a PR into Main.**