### PR TITLE
Save Location in UpdateCharacterStats() - Update OWSCharacterWithAbilities.cpp

### DIFF
--- a/plugins/OWSPluginUE5/Source/OWSPlugin/Private/OWSCharacterWithAbilities.cpp
+++ b/plugins/OWSPluginUE5/Source/OWSPlugin/Private/OWSCharacterWithAbilities.cpp
@@ -736,6 +736,15 @@ void AOWSCharacterWithAbilities::UpdateCharacterStats()
 		CharacterStats.UpdateCharacterStats.ReloadSpeed = OWSAttributes->ReloadSpeed.GetBaseValue();
 		CharacterStats.UpdateCharacterStats.Range = OWSAttributes->Range.GetBaseValue();
 		CharacterStats.UpdateCharacterStats.Speed = OWSAttributes->Speed.GetBaseValue();
+		
+		// Save Location also
+		CharacterStats.UpdateCharacterStats.X = this->GetActorLocation().X;
+		CharacterStats.UpdateCharacterStats.Y = this->GetActorLocation().Y;
+		CharacterStats.UpdateCharacterStats.Z = this->GetActorLocation().Z;
+		CharacterStats.UpdateCharacterStats.RX = this->GetActorRotation().Roll;
+		CharacterStats.UpdateCharacterStats.RY = this->GetActorRotation().Pitch;
+		CharacterStats.UpdateCharacterStats.RZ = this->GetActorRotation().Yaw;
+		
 
 		FString PostParameters = "";
 		if (FJsonObjectConverter::UStructToJsonObjectString(CharacterStats, PostParameters))


### PR DESCRIPTION
Character always saved 0,0,0 as his position in the DB when logging off in the OpenWorldServer example project.

These Lines secure that position of the character is stored also.