### PR TITLE
Fixed database setup links on getting started doc pages

### DIFF
--- a/docs/getting-started/visual-studio-code.md
+++ b/docs/getting-started/visual-studio-code.md
@@ -95,4 +95,4 @@ nav_order: 2
    ```
 </details>
 
-[Next: Database setup](setup-database){: .btn .btn-outline }
+[Next: Database setup](database-setup){: .btn .btn-outline }

--- a/docs/getting-started/visual-studio.md
+++ b/docs/getting-started/visual-studio.md
@@ -89,4 +89,4 @@ nav_order: 1
    ```
 </details>
 
-[Next: Database setup](setup-database){: .btn .btn-outline }
+[Next: Database setup](database-setup){: .btn .btn-outline }


### PR DESCRIPTION
The 'Database setup' link at the bottom of both visual studio and visual studio code getting started pages was incorrectly pointing to 'setup-database' instead of 'database-setup'