### PR TITLE
Added GetDefaultCustomData to the public API.

### DIFF
--- a/src/OWSData/Models/Composites/DefaultCustomDataDTO.cs
+++ b/src/OWSData/Models/Composites/DefaultCustomDataDTO.cs
@@ -1,0 +1,8 @@
+﻿namespace OWSData.Models.Composites
+{
+    public class DefaultCustomDataDTO
+    {
+        public string CustomFieldName { get; set; }
+        public string FieldValue { get; set; }
+    }
+}

--- a/src/OWSData/Models/Composites/DefaultCustomDataRows.cs
+++ b/src/OWSData/Models/Composites/DefaultCustomDataRows.cs
@@ -1,0 +1,12 @@
+﻿using OWSData.Models.Tables;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace OWSData.Models.Composites
+{
+    public class DefaultCustomDataRows
+    {
+        public List<DefaultCustomData> Rows { get; set; }
+    }
+}

--- a/src/OWSData/Models/Tables/DefaultCustomData.cs
+++ b/src/OWSData/Models/Tables/DefaultCustomData.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace OWSData.Models.Tables
+{
+    public partial class DefaultCustomData
+    {
+     //   public Guid CustomerGuid { get; set; }
+      //  public int DefaultCustomCharacterDataId { get; set; }
+      //  public int DefaultCharacterValuesId { get; set; }
+        public string CustomFieldName { get; set; }
+        public string FieldValue { get; set; }
+
+    }
+}

--- a/src/OWSData/Repositories/Implementations/MSSQL/CharactersRepository.cs
+++ b/src/OWSData/Repositories/Implementations/MSSQL/CharactersRepository.cs
@@ -194,6 +194,24 @@ namespace OWSData.Repositories.Implementations.MSSQL
             return outputCharacter.FirstOrDefault();
         }
 
+        public async Task<IEnumerable<DefaultCustomData>> GetDefaultCustomCharacterData(Guid customerGUID, string defaultSetName)
+        {
+            IEnumerable<DefaultCustomData> outputDefaultCustomCharacterDataRows;
+
+            using (Connection)
+            {
+                var parameters = new DynamicParameters();
+                parameters.Add("@CustomerGUID", customerGUID);
+                parameters.Add("@DefaultSetName", defaultSetName);
+
+                outputDefaultCustomCharacterDataRows = await Connection.QueryAsync<DefaultCustomData>(GenericQueries.GetDefaultCharacterCustomDataByName,
+                    parameters,
+                    commandType: CommandType.Text);
+            }
+
+            return outputDefaultCustomCharacterDataRows;
+        }
+
         public async Task<IEnumerable<CustomCharacterData>> GetCustomCharacterData(Guid customerGUID, string characterName)
         {
             IEnumerable<CustomCharacterData> outputCustomCharacterDataRows;

--- a/src/OWSData/Repositories/Implementations/MySQL/CharactersRepository.cs
+++ b/src/OWSData/Repositories/Implementations/MySQL/CharactersRepository.cs
@@ -210,6 +210,23 @@ namespace OWSData.Repositories.Implementations.MySQL
 
             return outputCustomCharacterDataRows;
         }
+        public async Task<IEnumerable<DefaultCustomData>> GetDefaultCustomCharacterData(Guid customerGUID, string defaultSetName)
+        {
+            IEnumerable<DefaultCustomData> outputDefaultCustomCharacterDataRows;
+
+            using (Connection)
+            {
+                var parameters = new DynamicParameters();
+                parameters.Add("@CustomerGUID", customerGUID);
+                parameters.Add("@DefaultSetName", defaultSetName);
+
+                outputDefaultCustomCharacterDataRows = await Connection.QueryAsync<DefaultCustomData>(GenericQueries.GetDefaultCharacterCustomDataByName,
+                    parameters,
+                    commandType: CommandType.Text);
+            }
+
+            return outputDefaultCustomCharacterDataRows;
+        }
 
         public async Task<JoinMapByCharName> JoinMapByCharName(Guid customerGUID, string characterName, string zoneName, int playerGroupType)
         {

--- a/src/OWSData/Repositories/Implementations/Postgres/CharactersRepository.cs
+++ b/src/OWSData/Repositories/Implementations/Postgres/CharactersRepository.cs
@@ -210,6 +210,23 @@ namespace OWSData.Repositories.Implementations.Postgres
 
             return outputCustomCharacterDataRows;
         }
+        public async Task<IEnumerable<DefaultCustomData>> GetDefaultCustomCharacterData(Guid customerGUID, string defaultSetName)
+        {
+            IEnumerable<DefaultCustomData> outputDefaultCustomCharacterDataRows;
+
+            using (Connection)
+            {
+                var parameters = new DynamicParameters();
+                parameters.Add("@CustomerGUID", customerGUID);
+                parameters.Add("@DefaultSetName", defaultSetName);
+
+                outputDefaultCustomCharacterDataRows = await Connection.QueryAsync<DefaultCustomData>(GenericQueries.GetDefaultCustomCharacterDataByDefaultSetName,
+                    parameters,
+                    commandType: CommandType.Text);
+            }
+
+            return outputDefaultCustomCharacterDataRows;
+        }
 
         public async Task<JoinMapByCharName> JoinMapByCharName(Guid customerGUID, string characterName, string zoneName, int playerGroupType)
         {

--- a/src/OWSData/Repositories/Interfaces/ICharactersRepository.cs
+++ b/src/OWSData/Repositories/Interfaces/ICharactersRepository.cs
@@ -15,6 +15,7 @@ namespace OWSData.Repositories.Interfaces
         Task CleanUpInstances(Guid customerGUID);
         Task<GetCharByCharName> GetCharByCharName(Guid customerGUID, string characterName);
         Task<IEnumerable<CustomCharacterData>> GetCustomCharacterData(Guid customerGUID, string characterName);
+        Task<IEnumerable<DefaultCustomData>> GetDefaultCustomCharacterData(Guid customerGUID, string defaultSetName);
         Task<JoinMapByCharName> JoinMapByCharName(Guid customerGUID, string characterName, string zoneName, int playerGroupType);
         Task UpdateCharacterStats(UpdateCharacterStats updateCharacterStats);
         Task UpdatePosition(Guid customerGUID, string characterName, string mapName, float X, float Y, float Z, float RX, float RY, float RZ);

--- a/src/OWSData/SQL/GenericQueries.cs
+++ b/src/OWSData/SQL/GenericQueries.cs
@@ -123,7 +123,21 @@ namespace OWSData.SQL
 				WHERE CCD.CustomerGUID = @CustomerGUID
 				  AND C.CharName = @CharName";
 
-	    public static readonly string GetPlayerGroupIDByType = @"SELECT COALESCE(PG.PlayerGroupID, 0)
+        public static readonly string GetDefaultCharacterCustomDataByName = @"SELECT *
+				FROM CustomCharacterData CCD
+				INNER JOIN Characters C ON C.CharacterID = CCD.CharacterID
+				WHERE CCD.CustomerGUID = @CustomerGUID
+				  AND C.CharName = @DefaultSetName";
+
+        public static readonly string GetDefaultCustomCharacterDataByDefaultSetName = @"SELECT *
+				FROM DefaultCustomCharacterData DCCD
+				INNER JOIN DefaultCharacterValues DCV 
+					ON DCCD.DefaultCharacterValuesId = DCV.DefaultCharacterValuesId
+				WHERE DCV.DefaultSetName = @DefaultSetName
+				AND DCCD.CustomerGUID = @CustomerGUID";
+
+
+        public static readonly string GetPlayerGroupIDByType = @"SELECT COALESCE(PG.PlayerGroupID, 0)
 				FROM PlayerGroupCharacters PGC
 				INNER JOIN PlayerGroup PG ON PG.PlayerGroupID = PGC.PlayerGroupID
 				WHERE PGC.CustomerGUID = @CustomerGUID

--- a/src/OWSPublicAPI/Controllers/CharactersController.cs
+++ b/src/OWSPublicAPI/Controllers/CharactersController.cs
@@ -16,6 +16,7 @@ using OWSShared.Interfaces;
 using OWSPublicAPI.Requests.Characters;
 using OWSData.Repositories.Interfaces;
 using OWSPublicAPI.DTOs;
+using OWSData.Models.Composites;
 
 namespace OWSPublicAPI.Controllers
 {
@@ -34,6 +35,7 @@ namespace OWSPublicAPI.Controllers
         private readonly ICharactersRepository _charactersRepository;
         private readonly IHeaderCustomerGUID _customerGuid;
         private readonly ICustomCharacterDataSelector _customCharacterDataSelector;
+        private readonly ICustomDataSelector _customDataSelector;
         private readonly IGetReadOnlyPublicCharacterData _getReadOnlyPublicCharacterData;
 
         /// <summary>
@@ -43,13 +45,14 @@ namespace OWSPublicAPI.Controllers
         /// All dependencies are injected.
         /// </remarks>
         public CharactersController(Container container, IUsersRepository usersRepository, ICharactersRepository charactersRepository, IHeaderCustomerGUID customerGuid, 
-            ICustomCharacterDataSelector customCharacterDataSelector, IGetReadOnlyPublicCharacterData getReadOnlyPublicCharacterData)
+            ICustomCharacterDataSelector customCharacterDataSelector, ICustomDataSelector customDataSelector, IGetReadOnlyPublicCharacterData getReadOnlyPublicCharacterData)
         {
             _container = container;
             _usersRepository = usersRepository;
             _charactersRepository = charactersRepository;
             _customerGuid = customerGuid;
             _customCharacterDataSelector = customCharacterDataSelector;
+            _customDataSelector = customDataSelector;
             _getReadOnlyPublicCharacterData = getReadOnlyPublicCharacterData;
         }
 
@@ -85,5 +88,20 @@ namespace OWSPublicAPI.Controllers
             return await getByNameRequest.Handle();
         }
 
+        /// <summary>
+        /// Get Default Custom Character Data by defaultSetName.
+        /// </summary>
+        /// <remarks>
+        /// Get Default Custom Character Data by defaultSetName
+        /// </remarks>
+        [HttpPost]
+        [Route("GetDefaultCustomData")]
+        [Produces(typeof(DefaultCustomDataRows))]
+
+        public async Task<IActionResult> GetDefaultCustomData([FromBody] GetDefaultCustomrDataDTO request)
+        {
+            GetDefaultCustomDataRequest getDefaultCustomData = new GetDefaultCustomDataRequest(request, _usersRepository, _charactersRepository, _customerGuid, _customDataSelector, _getReadOnlyPublicCharacterData);
+            return await getDefaultCustomData.Handle();
+        }
     }
 }

--- a/src/OWSPublicAPI/DTOs/GetDefaultCustomrDataDTO.cs
+++ b/src/OWSPublicAPI/DTOs/GetDefaultCustomrDataDTO.cs
@@ -1,0 +1,27 @@
+﻿namespace OWSPublicAPI.DTOs
+{
+    /// <summary>
+    /// GetByNameDTO data transfer object
+    /// </summary>
+    /// <remarks>
+    /// GetByNameDTO is data transfer object for GetByNameRequest
+    /// </remarks>
+    public class GetDefaultCustomrDataDTO
+    {
+        /// <summary>
+        /// UserSessionGUID Request Parameter
+        /// </summary>
+        /// <remarks>
+        /// Contains the User Session GUID from the request
+        /// </remarks>
+        public string UserSessionGUID { get; set; }
+
+        /// <summary>
+        /// CharacterName Request Paramater
+        /// </summary>
+        /// <remarks>
+        /// Contains the Character Name from the request
+        /// </remarks>
+        public string DefaultSetName { get; set; }
+    }
+}

--- a/src/OWSPublicAPI/OWSPublicAPI.xml
+++ b/src/OWSPublicAPI/OWSPublicAPI.xml
@@ -12,7 +12,7 @@
             Contains character related API calls that are all publicly accessible.
             </remarks>
         </member>
-        <member name="M:OWSPublicAPI.Controllers.CharactersController.#ctor(SimpleInjector.Container,OWSData.Repositories.Interfaces.IUsersRepository,OWSData.Repositories.Interfaces.ICharactersRepository,OWSShared.Interfaces.IHeaderCustomerGUID,OWSShared.Interfaces.ICustomCharacterDataSelector,OWSShared.Interfaces.IGetReadOnlyPublicCharacterData)">
+        <member name="M:OWSPublicAPI.Controllers.CharactersController.#ctor(SimpleInjector.Container,OWSData.Repositories.Interfaces.IUsersRepository,OWSData.Repositories.Interfaces.ICharactersRepository,OWSShared.Interfaces.IHeaderCustomerGUID,OWSShared.Interfaces.ICustomCharacterDataSelector,OWSShared.Interfaces.ICustomDataSelector,OWSShared.Interfaces.IGetReadOnlyPublicCharacterData)">
             <summary>
             Constructor for Public Character related API calls.
             </summary>
@@ -34,6 +34,14 @@
             </summary>
             <remarks>
             Gets a Characters by Name.
+            </remarks>
+        </member>
+        <member name="M:OWSPublicAPI.Controllers.CharactersController.GetDefaultCustomData(OWSPublicAPI.DTOs.GetDefaultCustomrDataDTO)">
+            <summary>
+            Get Default Custom Character Data by defaultSetName.
+            </summary>
+            <remarks>
+            Get Default Custom Character Data by defaultSetName
             </remarks>
         </member>
         <member name="T:OWSPublicAPI.Controllers.SystemController">
@@ -230,6 +238,30 @@
             Contains the Character Name from the request
             </remarks>
         </member>
+        <member name="T:OWSPublicAPI.DTOs.GetDefaultCustomrDataDTO">
+            <summary>
+            GetByNameDTO data transfer object
+            </summary>
+            <remarks>
+            GetByNameDTO is data transfer object for GetByNameRequest
+            </remarks>
+        </member>
+        <member name="P:OWSPublicAPI.DTOs.GetDefaultCustomrDataDTO.UserSessionGUID">
+            <summary>
+            UserSessionGUID Request Parameter
+            </summary>
+            <remarks>
+            Contains the User Session GUID from the request
+            </remarks>
+        </member>
+        <member name="P:OWSPublicAPI.DTOs.GetDefaultCustomrDataDTO.DefaultSetName">
+            <summary>
+            CharacterName Request Paramater
+            </summary>
+            <remarks>
+            Contains the Character Name from the request
+            </remarks>
+        </member>
         <member name="T:OWSPublicAPI.DTOs.RegisterUserDTO">
             <summary>
             RegisterUser Data Transfer Object
@@ -313,6 +345,30 @@
         <member name="M:OWSPublicAPI.Requests.Characters.GetByNameRequest.Handle">
             <summary>
             Handles the GetByNameRequest
+            </summary>
+            <remarks>
+            Overrides IRequestHandler Handle().
+            </remarks>
+        </member>
+        <member name="T:OWSPublicAPI.Requests.Characters.GetDefaultCustomDataRequest">
+            <summary>
+            GetByNameRequest Handler
+            </summary>
+            <remarks>
+            Handles api/Characters/GetByName requests.
+            </remarks>
+        </member>
+        <member name="M:OWSPublicAPI.Requests.Characters.GetDefaultCustomDataRequest.#ctor(OWSPublicAPI.DTOs.GetDefaultCustomrDataDTO,OWSData.Repositories.Interfaces.IUsersRepository,OWSData.Repositories.Interfaces.ICharactersRepository,OWSShared.Interfaces.IHeaderCustomerGUID,OWSShared.Interfaces.ICustomDataSelector,OWSShared.Interfaces.IGetReadOnlyPublicCharacterData)">
+            <summary>
+            Constructor for GetDefaultCustomerCharacterDataRequest
+            </summary>
+            <remarks>
+            Injects the dependencies for the GetDefaultCustomerCharacterDataRequest.
+            </remarks>
+        </member>
+        <member name="M:OWSPublicAPI.Requests.Characters.GetDefaultCustomDataRequest.Handle">
+            <summary>
+            Handles the GetDefaultCustomerCharacterDataRequest
             </summary>
             <remarks>
             Overrides IRequestHandler Handle().

--- a/src/OWSPublicAPI/Requests/Characters/GetDefaultCustomDataRequest.cs
+++ b/src/OWSPublicAPI/Requests/Characters/GetDefaultCustomDataRequest.cs
@@ -1,0 +1,98 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using OWSData.Models.Composites;
+using OWSData.Models.StoredProcs;
+using OWSData.Models.Tables;
+using OWSData.Repositories.Interfaces;
+using OWSPublicAPI.DTOs;
+using OWSShared.Interfaces;
+
+namespace OWSPublicAPI.Requests.Characters
+{
+    /// <summary>
+    /// GetByNameRequest Handler
+    /// </summary>
+    /// <remarks>
+    /// Handles api/Characters/GetByName requests.
+    /// </remarks>
+    public class GetDefaultCustomDataRequest : IRequestHandler<GetDefaultCustomDataRequest, IActionResult>, IRequest
+    {
+        private readonly GetDefaultCustomrDataDTO _getDefaultCustomCharacterDataDTO;
+        private readonly Guid _customerGUID;
+        private readonly IUsersRepository _usersRepository;
+        private readonly ICharactersRepository _charactersRepository;
+        private readonly ICustomDataSelector _customDataSelector;
+        private readonly IGetReadOnlyPublicCharacterData _getReadOnlyPublicCharacterData;
+
+        /// <summary>
+        /// Constructor for GetDefaultCustomerCharacterDataRequest
+        /// </summary>
+        /// <remarks>
+        /// Injects the dependencies for the GetDefaultCustomerCharacterDataRequest.
+        /// </remarks>
+        public GetDefaultCustomDataRequest(GetDefaultCustomrDataDTO getDefaultCustomCharacterDataDTO, IUsersRepository usersRepository, ICharactersRepository charactersRepository, IHeaderCustomerGUID customerGuid, 
+            ICustomDataSelector customDataSelector, IGetReadOnlyPublicCharacterData getReadOnlyPublicCharacterData)
+        {
+            _getDefaultCustomCharacterDataDTO = getDefaultCustomCharacterDataDTO;
+            _customerGUID = customerGuid.CustomerGUID;
+            _usersRepository = usersRepository;
+            _charactersRepository = charactersRepository;
+            _customDataSelector = customDataSelector;
+            _getReadOnlyPublicCharacterData = getReadOnlyPublicCharacterData;
+        }
+
+        /// <summary>
+        /// Handles the GetDefaultCustomerCharacterDataRequest
+        /// </summary>
+        /// <remarks>
+        /// Overrides IRequestHandler Handle().
+        /// </remarks>
+        public async Task<IActionResult> Handle()
+        {
+            DefaultCustomDataRows Output = new DefaultCustomDataRows();
+
+            //Test if a valid Guid was passed
+            if (!Guid.TryParse(_getDefaultCustomCharacterDataDTO.UserSessionGUID, out Guid parsedGuid))
+            {
+                return new BadRequestObjectResult(Output);
+            }
+
+            //Get the User Session
+            GetUserSession userSession = await _usersRepository.GetUserSession(_customerGUID, parsedGuid);
+
+            //Make sure the User Session is valid
+            if (userSession == null || !userSession.UserGuid.HasValue)
+            {
+                return new BadRequestObjectResult(Output);
+            }
+
+            IEnumerable<DefaultCustomData> customDataItems = await _charactersRepository.GetDefaultCustomCharacterData(_customerGUID, _getDefaultCustomCharacterDataDTO.DefaultSetName);
+            Output.Rows = new List<DefaultCustomData>();
+            //Loop through all the CustomCharacterData rows
+
+            foreach (DefaultCustomData currentCustomData in customDataItems)
+            {
+                //Use the ICustomCharacterDataSelector implementation to filter which fields are returned
+                if (_customDataSelector.ShouldExportThisCustomDataField(currentCustomData.CustomFieldName))
+                {
+                    DefaultCustomData customDataDTO = new DefaultCustomData()
+                    {
+                        CustomFieldName = currentCustomData.CustomFieldName,
+                        FieldValue = currentCustomData.FieldValue
+                    };
+                    //Add the filtered Custom Character Data
+                    Output.Rows.Add(customDataDTO);
+                }
+            }
+
+            // Output.Rows = await _charactersRepository.GetDefaultCustomCharacterData(_customerGUID, _getDefaultCustomCharacterDataDTO.DefaultSetName);
+
+
+            return new OkObjectResult(Output);
+        }
+    }
+}

--- a/src/OWSPublicAPI/Startup.cs
+++ b/src/OWSPublicAPI/Startup.cs
@@ -187,6 +187,7 @@ namespace OWSPublicAPI
 
             container.Register<IPublicAPIInputValidation, DefaultPublicAPIInputValidation>(Lifestyle.Singleton);
             container.Register<ICustomCharacterDataSelector, DefaultCustomCharacterDataSelector>(Lifestyle.Singleton);
+            container.Register<ICustomDataSelector, DefaultCustomDataSelector>(Lifestyle.Singleton);
             container.Register<IGetReadOnlyPublicCharacterData, DefaultGetReadOnlyPublicCharacterData>(Lifestyle.Singleton);
             container.Register<IHeaderCustomerGUID, HeaderCustomerGUID>(Lifestyle.Scoped);
 

--- a/src/OWSShared/Implementations/DefaultCustomDataSelector.cs
+++ b/src/OWSShared/Implementations/DefaultCustomDataSelector.cs
@@ -1,0 +1,22 @@
+﻿using OWSShared.Interfaces;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace OWSShared.Implementations
+{
+    public class DefaultCustomDataSelector : ICustomDataSelector
+    {
+        public bool ShouldExportThisCustomDataField(string fieldName)
+        {
+            return fieldName switch
+            {
+                "BaseCharacterStats" => true,
+                "CharacterExperience" => true,
+                _ => false,
+            };
+        }
+    }
+}

--- a/src/OWSShared/Interfaces/ICustomDataSelector.cs
+++ b/src/OWSShared/Interfaces/ICustomDataSelector.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace OWSShared.Interfaces
+{
+    public interface ICustomDataSelector
+    {
+        bool ShouldExportThisCustomDataField(string fieldName);
+    }
+}


### PR DESCRIPTION
Added GetDefaultCustomData to the OWSPublicAPI as well as a DataSelector to filter the results.  This allows you to get any defaultcustomcharacterdata rows that match the filter and are associated with the defaultSetName in defaultcharactervalues